### PR TITLE
Forwarding `restrictedToMinimumLevel` to `LoggerConfiguration.Sink`

### DIFF
--- a/Serilog.Sinks.Syslog/LoggerConfigurationSyslogExtensions.cs
+++ b/Serilog.Sinks.Syslog/LoggerConfigurationSyslogExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Serilog.Configuration;
+using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.Syslog;
 
@@ -22,15 +23,16 @@ namespace Serilog
     /// <param name="period">The time to wait between checking for event batches.</param>
     /// <param name="queueLimit">Maximum number of events in the queue.</param>
     /// <param name="outputTemplate">A message template describing the output messages.See https://github.com/serilog/serilog/wiki/Formatting-Output.</param>
-    public static LoggerConfiguration Syslog(this LoggerSinkConfiguration loggerSinkConfiguration, string server, int port, string application, Facility facility = Facility.User, int? batchSizeLimit = null, TimeSpan? period = null, int? queueLimit = null, string outputTemplate = null)
-        {
-            var messageTemplateTextFormatter = String.IsNullOrWhiteSpace(outputTemplate) ? null : new MessageTemplateTextFormatter(outputTemplate, null);
-            var syslogFormatter = new SyslogFormatter(application, facility, messageTemplateTextFormatter);
-            var sink =
-                queueLimit.HasValue ?
-                new SyslogSink(server, port, batchSizeLimit ?? SyslogSink.DefaultBatchPostingLimit, period ?? SyslogSink.DefaultPeriod, queueLimit.Value, syslogFormatter) :
-                new SyslogSink(server, port, batchSizeLimit ?? SyslogSink.DefaultBatchPostingLimit, period ?? SyslogSink.DefaultPeriod, syslogFormatter) ;
-            return loggerSinkConfiguration.Sink(sink);
-        }
+    /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink.</param>
+    public static LoggerConfiguration Syslog(this LoggerSinkConfiguration loggerSinkConfiguration, string server, int port, string application, Facility facility = Facility.User, int? batchSizeLimit = null, TimeSpan? period = null, int? queueLimit = null, string outputTemplate = null, LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose)
+    {
+        var messageTemplateTextFormatter = String.IsNullOrWhiteSpace(outputTemplate) ? null : new MessageTemplateTextFormatter(outputTemplate, null);
+        var syslogFormatter = new SyslogFormatter(application, facility, messageTemplateTextFormatter);
+        var sink =
+            queueLimit.HasValue ?
+            new SyslogSink(server, port, batchSizeLimit ?? SyslogSink.DefaultBatchPostingLimit, period ?? SyslogSink.DefaultPeriod, queueLimit.Value, syslogFormatter) :
+            new SyslogSink(server, port, batchSizeLimit ?? SyslogSink.DefaultBatchPostingLimit, period ?? SyslogSink.DefaultPeriod, syslogFormatter) ;
+        return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel);
+    }
     }
 }


### PR DESCRIPTION
Hi,

It is quite common for Serilog Sink packages to forward this parameter to logger configuration. I took the liberty to add it, defaulting to Verbose so it remains perfectly backward compatible.

Cheers!