### PR TITLE
allow host name prefix

### DIFF
--- a/Serilog.Sinks.Syslog.Tests/Tests.fs
+++ b/Serilog.Sinks.Syslog.Tests/Tests.fs
@@ -13,7 +13,7 @@ let setup =
     Log.Logger <-
       LoggerConfiguration()
         .MinimumLevel.Verbose()
-        .WriteTo.Syslog("127.0.0.1", udpServer.Port, "test", Facility.User, Nullable 1, TimeSpan.FromMilliseconds 100. |> Nullable)
+        .WriteTo.Syslog("127.0.0.1", udpServer.Port, "test", Facility.User, Nullable 1, TimeSpan.FromMilliseconds 100. |> Nullable, hostNamePrefix="testPrefix")
         .Enrich.WithProcessId()
         .CreateLogger()
     udpServer
@@ -35,7 +35,7 @@ let tests =
       let log = Log.ForContext<FooBar>()
       log.Error("Error {$foo}", @"""bar[]\""")
       udpServer.Wait()
-      let localHostName = Dns.GetHostName()
+      let localHostName = "testPrefix"+Dns.GetHostName()
       let pri, timestamp, hostname, application, processId, messageId, structuredData, message = udpServer.Requests.Dequeue() |> mtch
       Expect.equal pri "11" "pri"
       Expect.isMatch timestamp """\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2}""" "timestamp"

--- a/Serilog.Sinks.Syslog.sln
+++ b/Serilog.Sinks.Syslog.sln
@@ -1,11 +1,10 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29924.181
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Syslog", "Serilog.Sinks.Syslog\Serilog.Sinks.Syslog.csproj", "{81F02585-CF04-4D88-BE73-675464B05210}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Sinks.Syslog", "Serilog.Sinks.Syslog\Serilog.Sinks.Syslog.csproj", "{81F02585-CF04-4D88-BE73-675464B05210}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Serilog.Sinks.Syslog.Tests", "Serilog.Sinks.Syslog.Tests\Serilog.Sinks.Syslog.Tests.fsproj", "{4F5E819A-BA47-4217-8D86-6E7A416A135A}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Serilog.Sinks.Syslog.Tests", "Serilog.Sinks.Syslog.Tests\Serilog.Sinks.Syslog.Tests.fsproj", "{4F5E819A-BA47-4217-8D86-6E7A416A135A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,33 +15,36 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{81F02585-CF04-4D88-BE73-675464B05210}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{81F02585-CF04-4D88-BE73-675464B05210}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{81F02585-CF04-4D88-BE73-675464B05210}.Debug|x64.ActiveCfg = Debug|x64
-		{81F02585-CF04-4D88-BE73-675464B05210}.Debug|x64.Build.0 = Debug|x64
-		{81F02585-CF04-4D88-BE73-675464B05210}.Debug|x86.ActiveCfg = Debug|x86
-		{81F02585-CF04-4D88-BE73-675464B05210}.Debug|x86.Build.0 = Debug|x86
+		{81F02585-CF04-4D88-BE73-675464B05210}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{81F02585-CF04-4D88-BE73-675464B05210}.Debug|x64.Build.0 = Debug|Any CPU
+		{81F02585-CF04-4D88-BE73-675464B05210}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{81F02585-CF04-4D88-BE73-675464B05210}.Debug|x86.Build.0 = Debug|Any CPU
 		{81F02585-CF04-4D88-BE73-675464B05210}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{81F02585-CF04-4D88-BE73-675464B05210}.Release|Any CPU.Build.0 = Release|Any CPU
-		{81F02585-CF04-4D88-BE73-675464B05210}.Release|x64.ActiveCfg = Release|x64
-		{81F02585-CF04-4D88-BE73-675464B05210}.Release|x64.Build.0 = Release|x64
-		{81F02585-CF04-4D88-BE73-675464B05210}.Release|x86.ActiveCfg = Release|x86
-		{81F02585-CF04-4D88-BE73-675464B05210}.Release|x86.Build.0 = Release|x86
+		{81F02585-CF04-4D88-BE73-675464B05210}.Release|x64.ActiveCfg = Release|Any CPU
+		{81F02585-CF04-4D88-BE73-675464B05210}.Release|x64.Build.0 = Release|Any CPU
+		{81F02585-CF04-4D88-BE73-675464B05210}.Release|x86.ActiveCfg = Release|Any CPU
+		{81F02585-CF04-4D88-BE73-675464B05210}.Release|x86.Build.0 = Release|Any CPU
 		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Debug|x64.ActiveCfg = Debug|x64
-		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Debug|x64.Build.0 = Debug|x64
-		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Debug|x86.ActiveCfg = Debug|x86
-		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Debug|x86.Build.0 = Debug|x86
+		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Debug|x64.Build.0 = Debug|Any CPU
+		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Debug|x86.Build.0 = Debug|Any CPU
 		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Release|x64.ActiveCfg = Release|x64
-		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Release|x64.Build.0 = Release|x64
-		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Release|x86.ActiveCfg = Release|x86
-		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Release|x86.Build.0 = Release|x86
+		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Release|x64.ActiveCfg = Release|Any CPU
+		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Release|x64.Build.0 = Release|Any CPU
+		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Release|x86.ActiveCfg = Release|Any CPU
+		{4F5E819A-BA47-4217-8D86-6E7A416A135A}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F9079933-4DD1-4513-B8D0-95F585E6DEFA}
 	EndGlobalSection
 EndGlobal

--- a/Serilog.Sinks.Syslog/LoggerConfigurationSyslogExtensions.cs
+++ b/Serilog.Sinks.Syslog/LoggerConfigurationSyslogExtensions.cs
@@ -24,10 +24,11 @@ namespace Serilog
     /// <param name="queueLimit">Maximum number of events in the queue.</param>
     /// <param name="outputTemplate">A message template describing the output messages.See https://github.com/serilog/serilog/wiki/Formatting-Output.</param>
     /// <param name="restrictedToMinimumLevel">The minimum level for events passed through the sink.</param>
-    public static LoggerConfiguration Syslog(this LoggerSinkConfiguration loggerSinkConfiguration, string server, int port, string application, Facility facility = Facility.User, int? batchSizeLimit = null, TimeSpan? period = null, int? queueLimit = null, string outputTemplate = null, LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose)
+    /// <param name="hostNamePrefix">A prefix that can be attached to the hostname to enable filtering e.g. in a kubernetes cluster</param>
+    public static LoggerConfiguration Syslog(this LoggerSinkConfiguration loggerSinkConfiguration, string server, int port, string application, Facility facility = Facility.User, int? batchSizeLimit = null, TimeSpan? period = null, int? queueLimit = null, string outputTemplate = null, LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose,string hostNamePrefix ="")
     {
         var messageTemplateTextFormatter = String.IsNullOrWhiteSpace(outputTemplate) ? null : new MessageTemplateTextFormatter(outputTemplate, null);
-        var syslogFormatter = new SyslogFormatter(application, facility, messageTemplateTextFormatter);
+        var syslogFormatter = new SyslogFormatter(application, facility, messageTemplateTextFormatter, hostNamePrefix);
         var sink =
             queueLimit.HasValue ?
             new SyslogSink(server, port, batchSizeLimit ?? SyslogSink.DefaultBatchPostingLimit, period ?? SyslogSink.DefaultPeriod, queueLimit.Value, syslogFormatter) :

--- a/Serilog.Sinks.Syslog/Serilog.Sinks.Syslog.csproj
+++ b/Serilog.Sinks.Syslog/Serilog.Sinks.Syslog.csproj
@@ -3,7 +3,7 @@
     <Description>Serilog sink that writes to a Syslog server</Description>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Tiny Blue Robots</Authors>
-    <TargetFrameworks>netstandard20;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard20;net472</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Syslog</AssemblyName>
     <PackageId>Serilog.Sinks.SyslogServer</PackageId>
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/Serilog.Sinks.Syslog/SyslogFormatter.cs
+++ b/Serilog.Sinks.Syslog/SyslogFormatter.cs
@@ -26,12 +26,14 @@ namespace Serilog.Sinks.Syslog
     readonly string _application;
     readonly Facility _facility;
     readonly MessageTemplateTextFormatter _messageTemplateTextFormatter;
+    readonly string _hostNamePrefix;
 
-    public SyslogFormatter(string application, Facility facility, MessageTemplateTextFormatter messageTemplateTextFormatter = null)
+    public SyslogFormatter(string application, Facility facility, MessageTemplateTextFormatter messageTemplateTextFormatter = null,string hostNamePrefix = "")
     {
       _application = application;
       _facility = facility;
       _messageTemplateTextFormatter = messageTemplateTextFormatter;
+      _hostNamePrefix = hostNamePrefix;
     }
 
     Severity MapLogEventLevelToSeverity(LogEventLevel logEventLevel)
@@ -79,11 +81,11 @@ namespace Serilog.Sinks.Syslog
       {
         try
         {
-          return Dns.GetHostName();
+          return _hostNamePrefix+Dns.GetHostName();
         }
         catch
         {
-          return new[] { "COMPUTERNAME", "HOSTNAME" }.Select(Environment.GetEnvironmentVariable).FirstOrDefault() ?? "-";
+          return _hostNamePrefix + (new[] { "COMPUTERNAME", "HOSTNAME" }.Select(Environment.GetEnvironmentVariable).FirstOrDefault() ?? "-");
         }
       }
 


### PR DESCRIPTION
Hi, 
I've got the requirement to enable more speaking hostnames in non single server environments (e.g. docker or kubernetes). Otherwise the hostname will change with each (maybe rolling) deployments which makes filtering in downstream systems (e.g. papertrail.io) very difficult.
Maybe you can look at the PR and see if this fits your idea?
I head to update the .net framework version to make it compile (otherwise it complained about wrong protection level on disposing the udpClient).

Cheers
Joscha