### PR TITLE
Timestamp compliance with RFC5424

### DIFF
--- a/Serilog.Sinks.Syslog.Tests/Tests.fs
+++ b/Serilog.Sinks.Syslog.Tests/Tests.fs
@@ -38,7 +38,7 @@ let tests =
       let localHostName = "testPrefix" + Dns.GetHostName()
       let pri, timestamp, hostname, application, processId, messageId, structuredData, message = udpServer.Requests.Dequeue() |> mtch
       Expect.equal pri "11" "pri"
-      Expect.isMatch timestamp """\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\+\d{2}:\d{2}""" "timestamp"
+      Expect.isMatch timestamp """\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,6}(\+|\-)\d{2}:\d{2}""" "timestamp"
       Expect.equal hostname localHostName "application"
       Expect.equal application "test" "application"
       Expect.isMatch processId "\\d+" "processId"

--- a/Serilog.Sinks.Syslog/SyslogFormatter.cs
+++ b/Serilog.Sinks.Syslog/SyslogFormatter.cs
@@ -95,7 +95,7 @@ namespace Serilog.Sinks.Syslog
       var structuredData = String.IsNullOrEmpty(structuredDataKvps) ? "-" : $"[structuredData@0 {structuredDataKvps}]";
       var syslogEvent = new SyslogEvent
       {
-        IsoTimeStamp = logEvent.Timestamp.ToString("O"),
+        IsoTimeStamp = logEvent.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.ffffffzzz"),
         HostName = getHostName(),
         Application = _application,
         ProcessId = processId,


### PR DESCRIPTION
## Timestamp compliance with RFC5424
As of [RCF5424](https://tools.ietf.org/html/rfc5424#section-6.2.3.1), TIME-SECFRAC should be no longer than 6 digits.
This solves issue #12 

## Test regex now works for GMT -  timezones (not only GMT +)
Test project regex was matching only GMT+ timezones. Now it matches GMT- timezones as well